### PR TITLE
fix(golint-ci): disable exhaustruct

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,3 +11,4 @@ linters:
     - golint
     - exhaustivestruct
     - structcheck
+    - exhaustruct


### PR DESCRIPTION
The kubernetes api does itself not always require all struct fields to be initialized. This prevented basic implementations and should therefor be disabled.