### PR TITLE
Feat/#45 show detailed container status

### DIFF
--- a/Explorer/src/components/container_detail_page.tsx
+++ b/Explorer/src/components/container_detail_page.tsx
@@ -3,22 +3,24 @@
 import { Table } from "flowbite-react";
 import { H1 } from "@/components/style_elements";
 import { HealthIndicatorBadge } from "@/components/health_indicators";
-import { ContainerDetails } from "@/lib/types/Container";
+import { Container, ContainerDetails } from "@/lib/types/Container";
+import { ReactNode } from "react";
 
 export default function ContainerDetailPage({
   container_details,
 }: {
   container_details: ContainerDetails;
 }): JSX.Element {
+  const container = container_details.container;
   return (
     <div>
       <div className="flex">
-        <H1 content={"Container ID " + container_details.id} />
-        <HealthIndicatorBadge status={container_details.status} />
+        <H1 content={"Container ID " + container.id} />
+        <HealthIndicatorBadge status={container.status} />
       </div>
       <div className="flex">
         <div className="w-1/4 w-max">
-          <ContainerDetailsWidget container_data={container_details} />
+          <ContainerDetailsWidget container_data={container} />
         </div>
         {/* <div className="w-1/2 w-max px-8">
           <ContainerWorkLoad />
@@ -140,7 +142,7 @@ function _ContainerChangelogWidget({
 function ContainerDetailsWidget({
   container_data,
 }: {
-  container_data: ContainerDetails;
+  container_data: Container;
 }): JSX.Element {
   return (
     <div className="p-0 w-max">
@@ -158,7 +160,7 @@ function ContainerDetailsWidget({
           {Object.entries(container_data).map(([name, value], index) => {
             if (value instanceof Date) {
               value = value.toUTCString();
-            } else if (typeof value === "boolean") {
+            } else if (value instanceof Boolean) {
               value = value ? "true" : "false";
             }
             return (

--- a/Explorer/src/components/container_detail_page.tsx
+++ b/Explorer/src/components/container_detail_page.tsx
@@ -3,12 +3,12 @@
 import { Table } from "flowbite-react";
 import { H1 } from "@/components/style_elements";
 import { HealthIndicatorBadge } from "@/components/health_indicators";
-import { Container } from "@/lib/types/Container";
+import { ContainerDetails } from "@/lib/types/Container";
 
 export default function ContainerDetailPage({
   container_details,
 }: {
-  container_details: Container;
+  container_details: ContainerDetails;
 }): JSX.Element {
   return (
     <div>
@@ -140,7 +140,7 @@ function _ContainerChangelogWidget({
 function ContainerDetailsWidget({
   container_data,
 }: {
-  container_data: Container;
+  container_data: ContainerDetails;
 }): JSX.Element {
   return (
     <div className="p-0 w-max">

--- a/Explorer/src/lib/db.ts
+++ b/Explorer/src/lib/db.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Container, ContainerList } from "./types/Container";
+import { ContainerDetails, ContainerList } from "./types/Container";
 import { Pool } from "pg";
 
 const pool = new Pool({
@@ -12,10 +12,10 @@ const pool = new Pool({
 
 export async function getContainerDetails(
   container_id: string
-): Promise<Container | undefined> {
+): Promise<ContainerDetails | undefined> {
   return (
     await pool.query(
-      "SELECT * FROM containers c WHERE container_id = $1 order by timestamp DESC limit 1",
+      "SELECT * FROM containers c LEFT JOIN container_states cs ON cs.id  = c.state_id WHERE c.container_id = $1 order by timestamp DESC limit 1",
       [container_id]
     )
   ).rows[0];

--- a/Explorer/src/lib/db.ts
+++ b/Explorer/src/lib/db.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { ContainerDetails, ContainerList } from "./types/Container";
+import { ContainerDetails, Container, ContainerList } from "./types/Container";
 import { Pool } from "pg";
 
 const pool = new Pool({
@@ -13,12 +13,34 @@ const pool = new Pool({
 export async function getContainerDetails(
   container_id: string
 ): Promise<ContainerDetails | undefined> {
-  return (
+  const res1 = (
     await pool.query(
-      "SELECT * FROM containers c LEFT JOIN container_states cs ON cs.id  = c.state_id WHERE c.container_id = $1 order by timestamp DESC limit 1",
+      "SELECT * FROM containers c WHERE c.container_id = $1 order by timestamp DESC limit 1",
       [container_id]
     )
   ).rows[0];
+  if (!res1) {
+    // No container found
+    return undefined;
+  }
+  const container: Container = {
+    id: res1.id,
+    timestamp: res1.timestamp,
+    container_id: res1.container_id,
+    pod_id: res1.container_id,
+    name: res1.name,
+    image: res1.image,
+    status: res1.status,
+    // ports: 0,
+    image_id: res1.image_id,
+    ready: res1.ready,
+    restart_count: res1.restart_count,
+    started: res1.started,
+    // state_id: 0,
+    // last_state_id: 0,
+  };
+
+  return { container, status: {} };
 }
 
 export async function getContainerList(): Promise<ContainerList> {

--- a/Explorer/src/lib/types/Container.ts
+++ b/Explorer/src/lib/types/Container.ts
@@ -1,4 +1,14 @@
 import { Status } from "./Status";
+type ContainerStates =
+  | { kind: "running"; started_at: Date }
+  | {
+      kind: "terminated";
+      container_id: number;
+      exit_code: number;
+      finished_at: Date;
+      signal: number;
+    }
+  | { kind: "waiting"; message: string; reason: string };
 
 export type Container = {
   id: number;
@@ -16,4 +26,5 @@ export type Container = {
   state_id: number;
   last_state_id: number;
 };
+export type ContainerDetails = Container & ContainerStates;
 export type ContainerList = Container[];

--- a/Explorer/src/lib/types/Container.ts
+++ b/Explorer/src/lib/types/Container.ts
@@ -18,13 +18,13 @@ export type Container = {
   name: string;
   image: string;
   status: Status;
-  ports: number;
   image_id: string;
   ready: boolean;
   restart_count: number;
   started: boolean;
-  state_id: number;
-  last_state_id: number;
 };
-export type ContainerDetails = Container & ContainerStates;
+export type ContainerDetails = {
+  container: Container;
+  status: ContainerStates;
+};
 export type ContainerList = Container[];


### PR DESCRIPTION
This PR is not yet ready for merging because the current way keeps the empty fields from `container_status` even when they are not relevant